### PR TITLE
Fix `EEXIST` error on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ var rimraf = require('rimraf')
 
 var Tacks = module.exports = function (fixture) {
   this.fixture = fixture
-  computeFixturePaths('/', fixture)
+  computeFixturePaths('', fixture)
 }
 Tacks.prototype = {}
 
 // add path properties to everything relative to the fixture root
 function computeFixturePaths (entitypath, fixture) {
-  fixture.path = entitypath.slice(1)
+  fixture.path = entitypath
   if (fixture.type === 'dir') {
     Object.keys(fixture.contents).forEach(function (content) {
       computeFixturePaths(path.join(entitypath, content), fixture.contents[content])

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function computeFixturePaths (entitypath, fixture) {
   fixture.path = entitypath.slice(1)
   if (fixture.type === 'dir') {
     Object.keys(fixture.contents).forEach(function (content) {
-      computeFixturePaths(path.resolve(entitypath, content), fixture.contents[content])
+      computeFixturePaths(path.join(entitypath, content), fixture.contents[content])
     })
   } else if (fixture.type === 'file') {
     // do nothing


### PR DESCRIPTION
Use `path.join` instead of `path.resolve` because the latter results
in really terrible, awkward paths that cause a fairly unintuitive bug:

1. `path.resolve(entitypath, content)` on Windows (because of `C:\`) results in `:\path\to\fixture`
2. `fs.mkdirSync('exists/:')` results in an `ENOENT` error. Always.
3. `mkdirp.sync` looks for `ENOENT` and repeats the command, trying to create the *parent*
4. The parent ends up being `exists/`, which then makes `fs.mkdirSync` throw `EEXIST`

Basically, step 2's surprising(?) behavior is to blame and seems to happen because of REALLY LOW LEVEL STUFF.