### PR TITLE
Replace hard corded path sep with path.sep to support Windows

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -4,6 +4,7 @@ var rimraf = require('rimraf')
 module.exports = Entry
 
 function Entry (type, contents) {
+  if (type === 'symlink') contents = path.join(contents)
   this.type = type
   this.contents = contents
   this.path = null

--- a/load-from-dir.js
+++ b/load-from-dir.js
@@ -28,7 +28,7 @@ function loadFromDir (dir, top) {
     if (fileinfo.isSymbolicLink()) {
       var dest = fs.readlinkSync(filepath)
       if (/^(?:[a-z]\:)?[\\/]/i.test(dest)) {
-        dest = '/' + path.relative(top, dest)
+        dest = path.join('/', path.relative(top, dest))
       }
       dirInfo[filename] = Symlink(dest)
     } else if (fileinfo.isDirectory()) {

--- a/symlink.js
+++ b/symlink.js
@@ -17,8 +17,8 @@ inherits(Symlink, Entry)
 Symlink.prototype.create = function (where) {
   var filepath = path.resolve(where, this.path)
   var dest = this.contents
-  if (dest[0] === '/') {
-    dest = path.resolve(where, dest.slice(1))
+  if (dest.slice(0, path.sep.length) === path.sep) {
+    dest = path.resolve(where, dest.slice(path.sep.length))
   }
   fs.symlinkSync(dest, filepath, 'junction')
 }

--- a/tacks.js
+++ b/tacks.js
@@ -1,5 +1,6 @@
 'use strict'
 var fs = require('fs')
+var path = require('path')
 
 module.exports = Tacks
 
@@ -9,7 +10,7 @@ Tacks.Symlink = require('./symlink.js')
 
 function Tacks (fixture) {
   this.fixture = fixture
-  fixture.computePath('/')
+  fixture.computePath(path.sep)
 }
 Tacks.prototype = {}
 

--- a/tap.js
+++ b/tap.js
@@ -1,14 +1,16 @@
 'use strict'
+var path = require('path')
+
 exports.areTheSame = function (tap, actual, expected, msg) {
   return tap.test(msg, function (t) {
-    compare(t, '/', actual.fixture, expected.fixture)
+    compare(t, path.sep, actual.fixture, expected.fixture)
     t.done()
   })
 }
 
 function join (p1, p2) {
-  if (p1 === '/') return p1 + p2
-  return p1 + '/' + p2
+  if (p1 === path.sep) return p1 + p2
+  return path.join(p1, p2)
 }
 
 function compare (t, path, actual, expected) {


### PR DESCRIPTION
Since the ci still have errors, let me fix the part of the causes -
https://github.com/npm/npm/pull/14045
