### PR TITLE
Use Buffer.from

### DIFF
--- a/file.js
+++ b/file.js
@@ -65,7 +65,7 @@ function outputAsText (content) {
 
 function outputAsBuffer (content) {
   var chunks = content.toString('hex').match(/.{1,60}/g)
-  var output = 'new Buffer(\n'
+  var output = 'Buffer.from(\n'
   output += "  '" + chunks.shift() + "'"
   chunks.forEach(function (chunk) {
     output += ' +\n  ' + "'" + chunk + "'"

--- a/test/functional.js
+++ b/test/functional.js
@@ -32,7 +32,7 @@ var fixture = new Tacks(
     'foo': Dir({
       'foo.txt': Symlink('../a/b/c/foo.txt')
     }),
-    'binary.gz': File(new Buffer(
+    'binary.gz': File(Buffer.from(
       '1f8b0800d063115700034b4c4ae602004e81884704000000',
       'hex'
     )),


### PR DESCRIPTION
This should work according to https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

BREAKING CHANGE: drops support for Node <6